### PR TITLE
[Bugfix] modify sleep to 3 second for resupply

### DIFF
--- a/autofishbot.py
+++ b/autofishbot.py
@@ -360,7 +360,7 @@ def autoBuff(session: DiscordWrapper, queries: list = []) -> None:
             try:
                 if receiver_ready:
                     session.request(command=query[0], options=query[1])
-                sleep(2)
+                sleep(3)
             except Exception as e:
                 notify(f'Failed to send query -> {e}', 'e')
         return None


### PR DESCRIPTION
modify sleep to 3 seconds instead of 2 seconds while doing resupply

closes #35 